### PR TITLE
Fix documentation search function

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,43 @@
+name: Publish Documentation
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build Documentation
+        run: docker compose run nmag-docs
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload html documentation
+          path: 'nmag/build/html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.swp
+nmag/build

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Readme
+# nmag-docs
 
 This repository contains documentation for the micromagnetic simulation package Nmag. The user documentation can
 be found [here](http://nmag.readthedocs.io/en/latest/)
+
+## Dependencies
+
+- docker
+
+## Building
+
+`docker compose up`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,18 @@
+services:
+
+  docs-base:
+    build:
+      dockerfile_inline: |
+        FROM alpine
+        RUN apk add --no-cache make py3-sphinx py3-sphinx_rtd_theme texlive
+    image: docs-base
+    pull_policy: never
+
+  nmag-docs:
+    image: docs-base
+    depends_on: [docs-base]
+    pull_policy: never
+    working_dir: /app
+    command: make html
+    volumes:
+      - ./nmag:/app

--- a/nmag/source/conf.py
+++ b/nmag/source/conf.py
@@ -31,6 +31,7 @@
 # ones.
 extensions = [
     'sphinx.ext.mathjax',
+	'sphinx_rtd_theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -121,7 +122,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The search function on the documentation page is currently broken:
<img width="1191" height="675" alt="image" src="https://github.com/user-attachments/assets/f38a7038-0ab8-420e-b37e-bda2538475c9" />

I was able to fix this by building the documentation with a newer version of sphinx:
<img width="1181" height="779" alt="image" src="https://github.com/user-attachments/assets/73514c8d-6a66-4717-9114-bcaba3e6806b" />

I've also set up a github actions workflow to host the documentation using github pages